### PR TITLE
Add setup script for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ rent/
 
 ### 环境要求
 - **Java**: JDK 8+
-- **Node.js**: 16+
+- **Node.js**: 22+
 - **MySQL**: 5.7+
 - **Maven**: 3.6+
 
@@ -91,9 +91,17 @@ rent/
    cd rent
    ```
 2. **安装依赖**
-```bash
-./install-dependencies.sh
-```
+   根据系统选择对应脚本：
+   ```bash
+   # Linux
+   ./install-dependencies.sh
+
+   # macOS
+   ./install-dependencies-mac.sh
+
+   # Windows
+   PowerShell -ExecutionPolicy Bypass -File .\install-dependencies-win.ps1
+   ```
 3. **配置数据库**
    使用[sql脚本](sql/database.sql)创建数据库和表结构。
 4. **修改配置**

--- a/README.md
+++ b/README.md
@@ -90,13 +90,14 @@ rent/
    git clone https://github.com/penjc/rent
    cd rent
    ```
-
-2. **配置数据库**
-
+2. **安装依赖**
+```bash
+./install-dependencies.sh
+```
+3. **配置数据库**
    使用[sql脚本](sql/database.sql)创建数据库和表结构。
+4. **修改配置**
 
-
-3. **修改配置**
    ```yaml
    # src/main/resources/application-pro.yml
    spring:
@@ -106,29 +107,29 @@ rent/
        password: your_password
    ```
 
-4. **配置腾讯云COS**
+5. **配置腾讯云COS**
 
    修改`.env.example`为 `.env` 并填写相关配置。
 
 
-5. **安装前端依赖**
+6. **安装前端依赖**
    ```bash
    cd frontend
    npm install
    cd ..
    ```
 
-6. **构建后端**
+7. **构建后端**
    ```bash
    mvn clean compile
    ```
 
-7. **一键启动**
+8. **一键启动**
    ```bash
    ./start-all.sh
    ```
 
-8. **访问应用**
+9. **访问应用**
    - 前端应用: http://localhost:3000
    - 后端API: http://localhost:8080/api
 

--- a/install-dependencies-mac.sh
+++ b/install-dependencies-mac.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# macOS 安装脚本：安装 Java 8、Maven、Node.js 22 和 MySQL 5.7
+set -e
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "未检测到 Homebrew，请先安装 Homebrew" >&2
+  exit 1
+fi
+
+brew update
+brew install openjdk@8 maven node@22 mysql@5.7
+brew services start mysql@5.7
+
+cd frontend
+npm install
+cd ..
+
+echo "依赖安装完成 ✅"
+echo "请根据 README.md 配置数据库后执行 ./start-all.sh 启动项目"
+

--- a/install-dependencies-win.ps1
+++ b/install-dependencies-win.ps1
@@ -1,0 +1,23 @@
+# Windows 安装脚本：安装 Java 8、Maven、Node.js 22 和 MySQL 5.7
+
+if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Error "请以管理员身份运行 PowerShell"
+    exit 1
+}
+
+if (-not (Get-Command choco -ErrorAction SilentlyContinue)) {
+    Write-Output "安装 Chocolatey..."
+    Set-ExecutionPolicy Bypass -Scope Process -Force
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+    iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+}
+
+choco install -y openjdk8 maven nodejs --version=22.0.0 mysql --version=5.7
+
+cd frontend
+npm install
+cd ..
+
+Write-Output "依赖安装完成 ✅"
+Write-Output "请根据 README.md 配置数据库后执行 ./start-all.sh 启动项目"
+

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# 安装项目依赖脚本
+# 适用于 Ubuntu/Debian 系统，安装 Java、Maven、Node.js、npm 和 MySQL
+
+set -e
+
+if [ "$EUID" -ne 0 ]; then
+  echo "请以 root 身份或使用 sudo 运行该脚本" >&2
+  exit 1
+fi
+
+# 更新软件源
+apt-get update
+
+# 安装基本依赖
+apt-get install -y curl gnupg2
+
+# 安装 Java (OpenJDK 11)
+if ! command -v java >/dev/null 2>&1; then
+  apt-get install -y openjdk-11-jdk
+fi
+
+# 安装 Maven
+if ! command -v mvn >/dev/null 2>&1; then
+  apt-get install -y maven
+fi
+
+# 安装 Node.js 16.x (包含 npm)
+if ! command -v node >/dev/null 2>&1; then
+  curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+  apt-get install -y nodejs
+fi
+
+# 安装 MySQL Server
+if ! command -v mysql >/dev/null 2>&1; then
+  DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server
+fi
+
+# 安装前端依赖
+cd frontend
+npm install
+cd ..
+
+cat <<'INFO'
+依赖安装完成 ✅
+请根据 README.md 配置数据库和环境变量后执行 ./start-all.sh 启动项目
+INFO
+

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # 安装项目依赖脚本
-# 适用于 Ubuntu/Debian 系统，安装 Java、Maven、Node.js、npm 和 MySQL
+# 适用于 Ubuntu/Debian 系统，安装 Java 8、Maven、Node.js 22 和 MySQL 5.7
 
 set -e
 
@@ -16,9 +16,9 @@ apt-get update
 # 安装基本依赖
 apt-get install -y curl gnupg2
 
-# 安装 Java (OpenJDK 11)
+# 安装 Java (OpenJDK 8)
 if ! command -v java >/dev/null 2>&1; then
-  apt-get install -y openjdk-11-jdk
+  apt-get install -y openjdk-8-jdk
 fi
 
 # 安装 Maven
@@ -26,15 +26,15 @@ if ! command -v mvn >/dev/null 2>&1; then
   apt-get install -y maven
 fi
 
-# 安装 Node.js 16.x (包含 npm)
+# 安装 Node.js 22.x (包含 npm)
 if ! command -v node >/dev/null 2>&1; then
-  curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+  curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
   apt-get install -y nodejs
 fi
 
-# 安装 MySQL Server
+# 安装 MySQL Server 5.7
 if ! command -v mysql >/dev/null 2>&1; then
-  DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server
+  DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server-5.7
 fi
 
 # 安装前端依赖

--- a/start-all.sh
+++ b/start-all.sh
@@ -11,7 +11,7 @@ fi
 
 # 检查Node.js环境
 if ! command -v node &> /dev/null; then
-    echo "❌ 未找到Node.js环境，请先安装Node.js 16+"
+    echo "❌ 未找到Node.js环境，请先安装Node.js 22+"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- add `install-dependencies.sh` to automate installing Java, Maven, Node.js and MySQL
- update README with new installation step referencing the script

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c00a54620832680adce342bcf01ba